### PR TITLE
FOGL-7513 package name added in Package file

### DIFF
--- a/Package
+++ b/Package
@@ -3,6 +3,7 @@
 plugin_name=lathe
 plugin_type=south
 plugin_install_dirname=lathesim
+plugin_package_name=fledge-${plugin_type}-${plugin_name}
 
 # Now build up the runtime requirements list. This has 3 components
 #   1. Generic packages we depend on in all architectures and package managers


### PR DESCRIPTION
```
$ sudo dpkg -c fledge-south-lathe_2.1.0-2_x86_64.deb 
drwxrwxr-x ubuntu/ubuntu     0 2023-03-10 15:30 ./
drwxrwxr-x ubuntu/ubuntu     0 2023-03-10 15:30 ./usr/
drwxrwxr-x ubuntu/ubuntu     0 2023-03-10 15:30 ./usr/local/
drwxrwxr-x ubuntu/ubuntu     0 2023-03-10 15:30 ./usr/local/fledge/
drwxrwxr-x ubuntu/ubuntu     0 2023-03-10 15:30 ./usr/local/fledge/plugins/
drwxrwxr-x ubuntu/ubuntu     0 2023-03-10 15:30 ./usr/local/fledge/plugins/south/
drwxrwxr-x ubuntu/ubuntu     0 2023-03-10 15:30 ./usr/local/fledge/plugins/south/lathesim/
-rw-rw-r-- ubuntu/ubuntu    19 2023-03-10 15:30 ./usr/local/fledge/plugins/south/lathesim/.Package
-rwxrwxr-x ubuntu/ubuntu 41112 2023-03-10 15:30 ./usr/local/fledge/plugins/south/lathesim/liblathesim.so.1
lrwxrwxrwx ubuntu/ubuntu     0 2023-03-10 15:30 ./usr/local/fledge/plugins/south/lathesim/liblathesim.so -> liblathesim.so.1
```

API results:

```
{
      "name": "lathesim",
      "type": "south",
      "description": "A simulation of a lathe",
      "version": "2.1.0-2-g9b1b348",
      "installedDirectory": "south/lathesim",
      "packageName": "fledge-south-lathe"
    },
```